### PR TITLE
Enable RDF output on GET

### DIFF
--- a/lambdora-http-api/src/main/java/org/fcrepo/http/commons/responses/RdfStreamProvider.java
+++ b/lambdora-http-api/src/main/java/org/fcrepo/http/commons/responses/RdfStreamProvider.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
 
 /**
@@ -48,7 +49,7 @@ import org.slf4j.Logger;
  */
 @Provider
 @Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, TURTLE_X, JSON_LD})
-public class RdfStreamProvider implements MessageBodyWriter<RdfNamespacedStream> {
+public class RdfStreamProvider implements MessageBodyWriter<DefaultRdfStream> {
 
     private static final Logger LOGGER = getLogger(RdfStreamProvider.class);
 
@@ -58,7 +59,7 @@ public class RdfStreamProvider implements MessageBodyWriter<RdfNamespacedStream>
         LOGGER.debug(
                 "Checking to see if we can serialize type: {} to mimeType: {}",
                 type.getName(), mediaType.toString());
-        if (!RdfNamespacedStream.class.isAssignableFrom(type)) {
+        if (!DefaultRdfStream.class.isAssignableFrom(type)) {
             return false;
         }
         if (mediaType.equals(TEXT_HTML_TYPE)
@@ -72,7 +73,7 @@ public class RdfStreamProvider implements MessageBodyWriter<RdfNamespacedStream>
     }
 
     @Override
-    public long getSize(final RdfNamespacedStream t, final Class<?> type,
+    public long getSize(final DefaultRdfStream t, final Class<?> type,
             final Type genericType, final Annotation[] annotations,
             final MediaType mediaType) {
         // We do not know how long the stream is
@@ -80,15 +81,14 @@ public class RdfStreamProvider implements MessageBodyWriter<RdfNamespacedStream>
     }
 
     @Override
-    public void writeTo(final RdfNamespacedStream nsStream, final Class<?> type,
+    public void writeTo(final DefaultRdfStream stream, final Class<?> type,
         final Type genericType, final Annotation[] annotations,
         final MediaType mediaType,
         final MultivaluedMap<String, Object> httpHeaders,
         final OutputStream entityStream) {
 
         LOGGER.debug("Serializing an RdfStream to mimeType: {}", mediaType);
-        final RdfStreamStreamingOutput streamOutput = new RdfStreamStreamingOutput(nsStream.stream,
-                nsStream.namespaces, mediaType);
+        final RdfStreamStreamingOutput streamOutput = new RdfStreamStreamingOutput(stream, mediaType);
         streamOutput.write(entityStream);
     }
 }

--- a/lambdora-http-api/src/main/java/org/fcrepo/lambdora/ldp/LambdoraLdp.java
+++ b/lambdora-http-api/src/main/java/org/fcrepo/lambdora/ldp/LambdoraLdp.java
@@ -7,6 +7,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.lambdora.service.api.Container;
 import org.fcrepo.lambdora.service.api.ContainerService;
 import org.fcrepo.lambdora.service.api.LambdoraApplication;
@@ -31,7 +32,6 @@ import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Date;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -41,6 +41,7 @@ import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.WILDCARD;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.ok;
+import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
@@ -119,20 +120,9 @@ public class LambdoraLdp {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        /*
-         * This code is currently broken:  the apparent error:
-         * SEVERE: MessageBodyWriter not found for media type=text/n3;charset=utf-8,
-         * type=class org.fcrepo.kernel.api.rdf.DefaultRdfStream,
-         * genericType=class org.fcrepo.kernel.api.rdf.DefaultRdfStream.
-         */
-//         try (DefaultRdfStream stream = new DefaultRdfStream(createURI(container.getIdentifier().toString()),
-//                                                            container.getTriples())) {
-//            return ok(stream).build();
-//         }
-
-        //placehold until the above is fixed.
-        return ok("GET: Welcome to Lambdora. The current time is " + new Date() +
-                ". path=" + externalPath).build();
+        final DefaultRdfStream stream =
+                new DefaultRdfStream(createURI(container.getIdentifier().toString()), container.getTriples());
+        return ok(stream).build();
     }
 
     /**

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,6 +46,7 @@ functions:
           method: any
     onError:
       Ref: DeadLetterQueue
+    timeout: 20
 
 resources:
   Resources:


### PR DESCRIPTION
* Change MessageBodyWriter to respond to 'DefaultRdfStream'
* Remove namespace support from RdfStreamStreamingOutput
* Auto-closing of stream in LambdoraLdp was closing stream too soon
* Increase ApiGateway timeout from default(6) to 20sec