### PR TITLE
Fix #60 by ensuring we are loading existing resources instead of call…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ target
 *.war
 *.ear
 
+# Don't ignore gradle-wrapper distributed in project
+!/gradle/wrapper/gradle-wrapper.jar
+
 # Serverless directories
 .serverless

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ subprojects {
         systemProperty "java.library.path", 'build/libs'
     }
 
+    // Log exceptions of any unit test failures to stdout
+    test.testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
+
     //ensures that idea sees the generated source files in the src classpath
     def generated = new File(buildDir, "generated/source/apt/main")
 

--- a/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/BinaryServiceImpl.java
+++ b/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/BinaryServiceImpl.java
@@ -25,4 +25,9 @@ public class BinaryServiceImpl extends FedoraResourceServiceBase<FedoraBinary> i
     protected FedoraBinary create(final URI identifier) {
         return new FedoraBinaryImpl(identifier, getResourceTripleDao());
     }
+
+    @Override
+    protected FedoraBinary load(final URI identifier) {
+        return new FedoraBinaryImpl(identifier, getResourceTripleDao());
+    }
 }

--- a/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/ContainerServiceImpl.java
+++ b/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/ContainerServiceImpl.java
@@ -76,6 +76,13 @@ public class ContainerServiceImpl extends FedoraResourceServiceBase<Container> i
         return new ContainerImpl(identifier, dao);
     }
 
+    @Override
+    protected Container load(final URI identifier) {
+        LOGGER.debug("Load: {}", identifier);
+        final ResourceTripleDao dao = getResourceTripleDao();
+        return new ContainerImpl(identifier, dao);
+    }
+
     /**
      * Get system generated triples for this resource
      * @param identifier resource URI

--- a/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/FedoraResourceServiceBase.java
+++ b/lambdora-service/src/main/java/org/fcrepo/lambdora/service/aws/FedoraResourceServiceBase.java
@@ -34,7 +34,7 @@ public abstract class FedoraResourceServiceBase<T> implements Service<T> {
     @Override
     public T find(final URI identifier) {
         if (exists(identifier)) {
-            return create(identifier);
+            return load(identifier);
         } else {
             return null;
         }
@@ -63,4 +63,13 @@ public abstract class FedoraResourceServiceBase<T> implements Service<T> {
      * @return
      */
     abstract protected T create(final URI identifier);
+
+
+    /**
+     * load existing resource
+     *
+     * @param identifier
+     * @return
+     */
+    abstract protected T load(final URI identifier);
 }


### PR DESCRIPTION
Fixes #60

Adds a new `load()` method to `FedoraResourceServiceBase`, and implements for both Containers and Binaries. This `load()` method is called when the resource already exists.  Previously, we were calling `create()` on existing resources, and this resulted in a new "created" date being added every time the resource was accessed.

This PR also fixes a minor issue in the `.gitignore`. It was accidentally ignoring the `gradle-wrapper.jar` which is distributed with this project.